### PR TITLE
Load translation from the WordPress languages directory by default

### DIFF
--- a/ilmenite-cookie-consent.php
+++ b/ilmenite-cookie-consent.php
@@ -94,7 +94,10 @@ class Ilmenite_Cookie_Consent {
 	 * Load the Translations
 	 */
 	public function add_textdomain() {
-		load_plugin_textdomain( 'ilcc', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+		$domain = 'ilcc';
+
+		// Let users specify their own translations under WP_LANG_DIR 
+		load_plugin_textdomain( $domain ) || load_plugin_textdomain( $domain, false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	}
 
 	/**


### PR DESCRIPTION
I wanted to use my own translation of the plugin and this way it's easier to maintain. After this change it loads from wp-content/languages/plugins/ if it exists a translation their, otherwise it loads the shipped translation.

See how the function load_plugin_textdomain works here: https://core.trac.wordpress.org/browser/tags/4.2.2/src/wp-includes/l10n.php#L0

See a discussion on the topic here: http://geertdedeckere.be/article/loading-wordpress-language-files-the-right-way
