### PR TITLE
I think the constructor should be private

### DIFF
--- a/ilmenite-cookie-consent.php
+++ b/ilmenite-cookie-consent.php
@@ -59,7 +59,7 @@ class Ilmenite_Cookie_Consent {
 		return self::$_instance;
 	}
 
-	public function __construct() {
+	private function __construct() {
 
 		// Set Developer Mode Constant
 		if ( ! defined( 'ILCC_DEV_MODE' ) ) {


### PR DESCRIPTION
Thank you, it's really nice to have now have this plugin in the WordPress repository! The GitHub updater caused problem for me, so I was on a own fork, now I'm back on the official plugin.

When I switched back I found that the constructor is declared as public. Shouldn't it be private in a singleton pattern?