### PR TITLE
Add support for jQuery 3+

### DIFF
--- a/assets/scripts/src/cookie-banner.js
+++ b/assets/scripts/src/cookie-banner.js
@@ -127,7 +127,7 @@ const Ilmenite_Cookie_Consent = function( $, ilcc ) {
 	 * the cookie terms (ie. we have no cookie), then we
 	 * create the banner.
 	 */
-	$( window ).load( function() {
+	$( window ).on("load", function() {
 		if ( module.getCookieValue( module.settings.cookieName ) != module.settings.cookieActiveValue ) {
 			module.createBanner();
 		}


### PR DESCRIPTION
Thanks for this excellent plugin! 

Version 2 introduced an error in some of our projects, when using jQuery 3+ paired with the plugin. This error results in the banner not showing, since the `cookie-banner.js` script returns an error related to the jQuery load function.

This pull request solves support for jQuery 3 by replacing `.load( function()` with `.on("load", function()`.

I've tested this solution on a project, and it seems to be working. Let me know if I can do anything more.