### PR TITLE
Remove syncing debug mode with WP_DEBUG

### DIFF
--- a/ilmenite-cookie-consent.php
+++ b/ilmenite-cookie-consent.php
@@ -310,7 +310,7 @@ class Ilmenite_Cookie_Consent {
 	/**
 	 * Add body classes
 	 *
-	 * @param  array  $classes
+	 * @param array $classes
 	 *
 	 * @return array
 	 */
@@ -344,10 +344,6 @@ class Ilmenite_Cookie_Consent {
 	public function is_debugging() {
 		if ( defined( 'ILCC_DEBUG' ) ) {
 			return ILCC_DEBUG;
-		}
-
-		if ( defined( 'WP_DEBUG' ) ) {
-			return WP_DEBUG;
 		}
 
 		return false;


### PR DESCRIPTION
In previous versions we've honored `WP_DEBUG` as a way to enable the debug mode, and not just `ILCC_DEBUG`. In this PR we remove this. It has caused more problems than the feature was worth, and as it turned out, a nicer idea in theory than in practice.

You can still use `ILCC_DEBUG` to turn on the debug mode where no cookies are set.