### PR TITLE
Add matomo integration

### DIFF
--- a/assets/scripts/src/consent.js
+++ b/assets/scripts/src/consent.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getCookieValue, getJsonCookieValue, setCookie } from "./cookies";
-import { settings } from "./settings";
+import { hasMatomo, settings } from "./settings";
 
 /**
  * Set the "has set preferences" cookie.
@@ -26,6 +26,10 @@ export function setHasSetPreferences( hasSet = true ) {
  */
 export function setConsentedCategories( categories = [] ) {
 	setCookie( settings.consentedCategories, JSON.stringify( categories ) );
+
+	if ( hasMatomo() && hasConsentedTo( "analytics" ) ) {
+		_paq.push( [ "setCookieConsentGiven" ] );
+	}
 }
 
 /**

--- a/assets/scripts/src/index.js
+++ b/assets/scripts/src/index.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import { removeBanner, showBanner, toggleCategory, toggleSettings } from "./banner";
-import { hasUserSetPreferences, setConsentedCategories, setHasSetPreferences } from "./consent";
+import { hasConsentedTo, hasUserSetPreferences, setConsentedCategories, setHasSetPreferences } from "./consent";
 import { getJsonCookieValue } from "./cookies";
 import { log, logDebug, logInfo } from "./log";
-import { getBannerStyle, isConfigurable, isDebugging, settings } from "./settings";
+import { getBannerStyle, hasMatomo, isConfigurable, isDebugging, settings } from "./settings";
 
 log( "=========== COOKIE CONSENT DEBUGGING ===========" );
 
@@ -22,6 +22,11 @@ if ( hasUserSetPreferences() ) {
 	logDebug( "The following categories were granted:" );
 	logDebug( getJsonCookieValue( settings.consentedCategories ) );
 	document.body.classList.add( "has-ilcc-consented" );
+
+	if ( hasMatomo() && hasConsentedTo( "analytics" ) ) {
+		_paq.push( [ "setCookieConsentGiven" ] );
+	}
+
 } else {
 	logDebug( "❌ User has not expressed consent." );
 	document.body.classList.add( "has-ilcc-banner" );

--- a/assets/scripts/src/settings.js
+++ b/assets/scripts/src/settings.js
@@ -23,3 +23,7 @@ export function isMarketingShown() {
 export function isDebugging() {
 	return 1 === ilcc.debug;
 }
+
+export function hasMatomo() {
+	return typeof _paq !== "undefined";
+}


### PR DESCRIPTION
This PR adds integration with Matomo to trigger cookie consent if Matomo tracking exists on the page.